### PR TITLE
Derived Initializers interfaces and Multiple Implementations.

### DIFF
--- a/src/Extensions.Hosting.AsyncInitialization/DecoratedInitializer.cs
+++ b/src/Extensions.Hosting.AsyncInitialization/DecoratedInitializer.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Extensions.Hosting.AsyncInitialization
+{
+    internal class DecoratedInitializer : IAsyncInitializer
+    {
+        private readonly IAsyncInitializer _next;
+        private readonly DecoratedInitializer? _decoratedInitializer;
+
+        public DecoratedInitializer(IAsyncInitializer next, DecoratedInitializer decoratedInitializer) 
+            : this(decoratedInitializer ?? throw new ArgumentNullException(nameof(decoratedInitializer)))
+        {
+            _next = next ?? throw new ArgumentNullException(nameof(next));
+        }
+
+        public DecoratedInitializer(DecoratedInitializer? decoratedInitializer = null)
+        {
+            _decoratedInitializer = decoratedInitializer;
+        }
+
+        public async Task InitializeAsync()
+        {
+            if(_next != null)
+                await _next?.InitializeAsync();
+
+            if(_decoratedInitializer != null)
+                await _decoratedInitializer?.InitializeAsync();
+        }
+    }
+}

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/Extensions.Hosting.AsyncInitialization.Tests.csproj
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/Extensions.Hosting.AsyncInitialization.Tests.csproj
@@ -1,19 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp2.1;net471</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net471;net5.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <MSEHostingVersion Condition="'$(TargetFramework)' == 'netcoreapp2.1'">2.1.0</MSEHostingVersion>
-    <MSEHostingVersion Condition="'$(TargetFramework)' == 'net471'">2.1.0</MSEHostingVersion>
-    <MSEHostingVersion Condition="'$(TargetFramework)' == 'netcoreapp3.0'">3.0.0</MSEHostingVersion>
+	  <MSEHostingVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1'">3.1.0</MSEHostingVersion>
+	  <MSEHostingVersion Condition="'$(TargetFramework)' == 'net471'">2.1.0</MSEHostingVersion>
+	  <MSEHostingVersion Condition="'$(TargetFramework)' == 'net5.0'">5.0.0</MSEHostingVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="5.2.0" />
+    <PackageReference Include="FluentAssertions" Version="6.1.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MSEHostingVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net471" Version="1.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/StubsMocksAndDummies.cs
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/StubsMocksAndDummies.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Extensions.Hosting.AsyncInitialization.Tests
+{
+    public interface IDependency
+    {
+    }
+
+    public class Initializer : IAsyncInitializer
+    {
+        // ReSharper disable once NotAccessedField.Local
+        private readonly IDependency _dependency;
+
+        public Initializer(IDependency dependency)
+        {
+            _dependency = dependency;
+        }
+        public Task InitializeAsync() => Task.CompletedTask;
+    }
+
+    public interface IDummyInitializer : IAsyncInitializer
+    {
+
+    }
+
+    public class DummyInitializer : IDummyInitializer
+    {
+        private readonly Spy _spy;
+        public DummyInitializer(Spy spy)
+        {
+            _spy = spy;
+        }
+
+        public Task InitializeAsync()
+        {
+            _spy.Initialized = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    public class Spy
+    {
+        public bool Initialized { get; set; }
+    }
+
+    public class AnotherSpy : Spy
+    {
+
+    }
+
+    public class AnotherDummyInitializer : IDummyInitializer
+    {
+        private readonly AnotherSpy _anotherSpy;
+
+        public AnotherDummyInitializer(AnotherSpy anotherSpy)
+        {
+            _anotherSpy = anotherSpy;
+        }
+
+        public Task InitializeAsync()
+        {
+            _anotherSpy.Initialized = true;
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
# Problem 
The Async Initialization is not possible when trying to initialize using an interface derived from IAsyncInitializer.

### Example
```C#
public interface IDerivedInitializer: IAsyncInitializer
{
     /// methods exposed by this interface.
}

public class DerivedInitializer : IDerivedInitializer
{
       /// Implementations of methods.
}

public class Program
{
    static async Task Main(string[] args)
    {
          // This Throws Exception since Async initialization cannot add a derived interface as an 
          // implementation of IAsyncInitializer interface.
          Host.CreateDefaultBuilder()
               .ConfigureServices(services =>  services
                   .AddTransient<IDerivedInitializer, DerivedInitializer>()
                   .AddAsyncInitializer<IDerivedInitializer>())
                .Build()
                .InitAsync()
                .Run();
    }
}
```

### Solution

Changing implementation of "AddAsyncInitializer<TInitializer>()" method to check if TInitializer is an interface. 
it will look inside the service collection for an implementation of the derived interface and add it as a transient.

### What if I have more than one implementation of said derived TInializer?
No Problem! A decorator internal class "DecoratedInitializer" was created using [Decorator Pattern](https://refactoring.guru/design-patterns/decorator).

When more than one implementation of TInitializer is found, it starts creating decorated instances of this class and adds it as a a Transient TImplementation of IAsyncInitializer as follow.

```C#
public static IServiceCollection AddAsyncInitializer<TInitializer>(this IServiceCollection services)
            where TInitializer : class, IAsyncInitializer
        {
            services.AddAsyncInitialization();

            if (!typeof(TInitializer).IsInterface)
                return services.AddTransient<IAsyncInitializer, TInitializer>();

            if (HaveSingleRegisteredService<TInitializer>(services))
                return services.AddTransient<IAsyncInitializer>(x => x.GetRequiredService<TInitializer>());

            if (HaveMultipleRegisteredServices<TInitializer>(services))
                return services.AddDecoratedInitializers<TInitializer>();

            throw new InvalidOperationException($"No Implementation type found for type inteface {typeof(TInitializer).FullName}.");
        }

// more other methods from class

 private static IServiceCollection AddDecoratedInitializers<TInitializer>(this IServiceCollection services) where TInitializer : class, IAsyncInitializer
        {
            return services.AddTransient<IAsyncInitializer, DecoratedInitializer>(x =>
            {
                var initializersList = x.GetServices<TInitializer>();
                var decoratedInitializer = new DecoratedInitializer();

                foreach (var initializer in initializersList)
                {
                    var next = new DecoratedInitializer(initializer, decoratedInitializer);
                    decoratedInitializer = next;
                }

                return decoratedInitializer;
            });
        }
```
