### PR TITLE
Support for async teardown

### DIFF
--- a/Extensions.Hosting.AsyncInitialization.sln
+++ b/Extensions.Hosting.AsyncInitialization.sln
@@ -28,24 +28,18 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-		ReleaseLegacyHosting|Any CPU = ReleaseLegacyHosting|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{DEC4A732-9A80-4CC9-9775-D3A8CE65F633}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DEC4A732-9A80-4CC9-9775-D3A8CE65F633}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DEC4A732-9A80-4CC9-9775-D3A8CE65F633}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DEC4A732-9A80-4CC9-9775-D3A8CE65F633}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DEC4A732-9A80-4CC9-9775-D3A8CE65F633}.ReleaseLegacyHosting|Any CPU.ActiveCfg = ReleaseLegacyHosting|Any CPU
-		{DEC4A732-9A80-4CC9-9775-D3A8CE65F633}.ReleaseLegacyHosting|Any CPU.Build.0 = ReleaseLegacyHosting|Any CPU
 		{8264807E-AEEC-4A9F-8023-7B30B01F3FD2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8264807E-AEEC-4A9F-8023-7B30B01F3FD2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8264807E-AEEC-4A9F-8023-7B30B01F3FD2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8264807E-AEEC-4A9F-8023-7B30B01F3FD2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8264807E-AEEC-4A9F-8023-7B30B01F3FD2}.ReleaseLegacyHosting|Any CPU.ActiveCfg = ReleaseLegacyHosting|Any CPU
-		{8264807E-AEEC-4A9F-8023-7B30B01F3FD2}.ReleaseLegacyHosting|Any CPU.Build.0 = ReleaseLegacyHosting|Any CPU
 		{191B7D1C-7505-404B-8805-DD8E3EB44785}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{191B7D1C-7505-404B-8805-DD8E3EB44785}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{191B7D1C-7505-404B-8805-DD8E3EB44785}.ReleaseLegacyHosting|Any CPU.ActiveCfg = ReleaseLegacyHosting|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Extensions.Hosting.AsyncInitialization.sln
+++ b/Extensions.Hosting.AsyncInitialization.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{F3949869-0B22-4F63-8B97-B3548E7ED0AC}"
 EndProject
@@ -28,18 +28,24 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		ReleaseLegacyHosting|Any CPU = ReleaseLegacyHosting|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{DEC4A732-9A80-4CC9-9775-D3A8CE65F633}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DEC4A732-9A80-4CC9-9775-D3A8CE65F633}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DEC4A732-9A80-4CC9-9775-D3A8CE65F633}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DEC4A732-9A80-4CC9-9775-D3A8CE65F633}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DEC4A732-9A80-4CC9-9775-D3A8CE65F633}.ReleaseLegacyHosting|Any CPU.ActiveCfg = ReleaseLegacyHosting|Any CPU
+		{DEC4A732-9A80-4CC9-9775-D3A8CE65F633}.ReleaseLegacyHosting|Any CPU.Build.0 = ReleaseLegacyHosting|Any CPU
 		{8264807E-AEEC-4A9F-8023-7B30B01F3FD2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8264807E-AEEC-4A9F-8023-7B30B01F3FD2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8264807E-AEEC-4A9F-8023-7B30B01F3FD2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8264807E-AEEC-4A9F-8023-7B30B01F3FD2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8264807E-AEEC-4A9F-8023-7B30B01F3FD2}.ReleaseLegacyHosting|Any CPU.ActiveCfg = ReleaseLegacyHosting|Any CPU
+		{8264807E-AEEC-4A9F-8023-7B30B01F3FD2}.ReleaseLegacyHosting|Any CPU.Build.0 = ReleaseLegacyHosting|Any CPU
 		{191B7D1C-7505-404B-8805-DD8E3EB44785}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{191B7D1C-7505-404B-8805-DD8E3EB44785}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{191B7D1C-7505-404B-8805-DD8E3EB44785}.ReleaseLegacyHosting|Any CPU.ActiveCfg = ReleaseLegacyHosting|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Extensions.Hosting.AsyncInitialization/Extensions.Hosting.AsyncInitialization.csproj
+++ b/src/Extensions.Hosting.AsyncInitialization/Extensions.Hosting.AsyncInitialization.csproj
@@ -1,35 +1,30 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
-    <Authors>Thomas Levesque</Authors>
-    <Title>.NET Core generic host async initialization</Title>
-    <Description>A simple helper to perform async application initialization for the generic host in .NET 6.0 or higher.</Description>
-    <PackageProjectUrl>https://github.com/thomaslevesque/Extensions.Hosting.AsyncInitialization</PackageProjectUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageTags>.net core;hosting;async;initialization</PackageTags>
-    <RepositoryUrl>https://github.com/thomaslevesque/Extensions.Hosting.AsyncInitialization</RepositoryUrl>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-  </PropertyGroup>
-
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <Authors>Thomas Levesque</Authors>
+        <Title>.NET Core generic host async initialization</Title>
+        <Description>A simple helper to perform async application initialization for the generic host in .NET 6.0 or higher.</Description>
+        <PackageProjectUrl>https://github.com/thomaslevesque/Extensions.Hosting.AsyncInitialization</PackageProjectUrl>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <PackageTags>.net core;hosting;async;initialization</PackageTags>
+        <RepositoryUrl>https://github.com/thomaslevesque/Extensions.Hosting.AsyncInitialization</RepositoryUrl>
+        <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    </PropertyGroup>
 		
-  <PropertyGroup>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Extensions.Hosting.AsyncInitialization.xml</DocumentationFile>
-  </PropertyGroup>
-
+    <PropertyGroup>
+        <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Extensions.Hosting.AsyncInitialization.xml</DocumentationFile>
+    </PropertyGroup>
 		
-		
-  <ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="MinVer" Version="4.3.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-		
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+        <PackageReference Include="MinVer" Version="4.3.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
 </Project>

--- a/src/Extensions.Hosting.AsyncInitialization/Extensions.Hosting.AsyncInitialization.csproj
+++ b/src/Extensions.Hosting.AsyncInitialization/Extensions.Hosting.AsyncInitialization.csproj
@@ -12,14 +12,20 @@
     <PackageTags>.net core;hosting;async;initialization</PackageTags>
     <RepositoryUrl>https://github.com/thomaslevesque/Extensions.Hosting.AsyncInitialization</RepositoryUrl>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <Configurations>Debug;Release;ReleaseLegacyHosting</Configurations>
+		<MSEHostingVersion Condition="'$(Configuration)' == 'ReleaseLegacyHosting'">2.1.0</MSEHostingVersion>
+		<MSEHostingVersion Condition="'$(Configuration)' != 'ReleaseLegacyHosting'">6.0.0</MSEHostingVersion>
   </PropertyGroup>
 
+		
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Extensions.Hosting.AsyncInitialization.xml</DocumentationFile>
   </PropertyGroup>
 
+		
+		
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MSEHostingVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
@@ -28,5 +34,5 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-
+		
 </Project>

--- a/src/Extensions.Hosting.AsyncInitialization/Extensions.Hosting.AsyncInitialization.csproj
+++ b/src/Extensions.Hosting.AsyncInitialization/Extensions.Hosting.AsyncInitialization.csproj
@@ -12,9 +12,6 @@
     <PackageTags>.net core;hosting;async;initialization</PackageTags>
     <RepositoryUrl>https://github.com/thomaslevesque/Extensions.Hosting.AsyncInitialization</RepositoryUrl>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <Configurations>Debug;Release;ReleaseLegacyHosting</Configurations>
-		<MSEHostingVersion Condition="'$(Configuration)' == 'ReleaseLegacyHosting'">2.1.0</MSEHostingVersion>
-		<MSEHostingVersion Condition="'$(Configuration)' != 'ReleaseLegacyHosting'">6.0.0</MSEHostingVersion>
   </PropertyGroup>
 
 		
@@ -25,7 +22,7 @@
 		
 		
   <ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(MSEHostingVersion)" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />

--- a/src/Extensions.Hosting.AsyncInitialization/Extensions.Hosting.AsyncInitialization.csproj
+++ b/src/Extensions.Hosting.AsyncInitialization/Extensions.Hosting.AsyncInitialization.csproj
@@ -12,11 +12,11 @@
         <RepositoryUrl>https://github.com/thomaslevesque/Extensions.Hosting.AsyncInitialization</RepositoryUrl>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     </PropertyGroup>
-		
+    
     <PropertyGroup>
         <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\Extensions.Hosting.AsyncInitialization.xml</DocumentationFile>
     </PropertyGroup>
-		
+    
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />

--- a/src/Extensions.Hosting.AsyncInitialization/Hosting/AsyncInitializationHostExtensions.cs
+++ b/src/Extensions.Hosting.AsyncInitialization/Hosting/AsyncInitializationHostExtensions.cs
@@ -70,29 +70,17 @@ namespace Microsoft.Extensions.Hosting
         // wraps an IHost instance in an IAsyncDisposable 
         private static IAsyncDisposable AsAsyncDisposable(this IHost host)
         {
-            if (host == null) throw new ArgumentNullException(nameof(host));
-            return AsyncDisposableHostWrapper.Create(host);
+            return host as IAsyncDisposable ?? new AsyncDisposableHostWrapper(host);
         }
 
         // IAsyncDisposable wrapper for IHost
-        private class AsyncDisposableHostWrapper : IHost, IAsyncDisposable
+        private class AsyncDisposableHostWrapper : IAsyncDisposable
         {
             private readonly IHost _host;
             public AsyncDisposableHostWrapper(IHost host)
             {
                 _host = host ?? throw new ArgumentNullException(nameof(host));
             }
-
-            public static AsyncDisposableHostWrapper Create(IHost host) => new(host);
-
-            public IServiceProvider Services => _host.Services;
-
-            public Task StartAsync(CancellationToken cancellationToken = default) => _host.StartAsync(cancellationToken);
-            
-            public Task StopAsync(CancellationToken cancellationToken = default) => _host.StopAsync(cancellationToken);
-
-            public void Dispose() => _host.Dispose();
-            
             public ValueTask DisposeAsync()
             {
                 if (_host is IAsyncDisposable asyncDisposable)

--- a/src/Extensions.Hosting.AsyncInitialization/Hosting/AsyncInitializationHostExtensions.cs
+++ b/src/Extensions.Hosting.AsyncInitialization/Hosting/AsyncInitializationHostExtensions.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Extensions.Hosting
                     return asyncDisposable.DisposeAsync();
                 }
                 _host.Dispose();
-                return default;
+                return ValueTask.CompletedTask;
             }
         }
     }

--- a/src/Extensions.Hosting.AsyncInitialization/Hosting/AsyncInitializationHostExtensions.cs
+++ b/src/Extensions.Hosting.AsyncInitialization/Hosting/AsyncInitializationHostExtensions.cs
@@ -33,28 +33,6 @@ namespace Microsoft.Extensions.Hosting
             await rootInitializer.InitializeAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Performs application teardown by calling all registered async initializers implementing <see cref="IAsyncTeardown"/>.
-        /// </summary>
-        /// <param name="host">The host.</param>
-        /// <param name="cancellationToken">Optionally propagates notifications that the operation should be cancelled</param>
-        /// <returns>A task that represents the teardown completion.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when the host is null.</exception>
-        /// <exception cref="InvalidOperationException">Thrown when the initialization service has not been registered.</exception>
-        /// <exception cref="OperationCanceledException">Thrown when the cancellationToken is cancelled.</exception>
-        /// <exception cref="ObjectDisposedException">Thrown when the host has been disposed.</exception>
-        /// <remarks>Make sure not to call this method after the host has terminated, eg. after a call to RunAsync().</remarks>
-        public static async Task TeardownAsync(this IHost host, CancellationToken cancellationToken = default)
-        {
-            if (host == null)
-                throw new ArgumentNullException(nameof(host));
-
-            using var scope = host.Services.CreateScope();
-            var rootInitializer = scope.ServiceProvider.GetService<RootInitializer>()
-                ?? throw new InvalidOperationException("The async initialization service isn't registered, register it by calling AddAsyncInitialization() on the service collection or by adding an async initializer.");
-
-            await rootInitializer.TeardownAsync(cancellationToken).ConfigureAwait(false); 
-        }
 
         /// <summary>
         /// Initializes and runs the application, by first calling all registered async initializers.
@@ -66,7 +44,7 @@ namespace Microsoft.Extensions.Hosting
         /// <exception cref="ArgumentNullException">Thrown when the host is null.</exception>
         /// <exception cref="InvalidOperationException">Thrown when the initialization service has not been registered.</exception>
         /// <exception cref="OperationCanceledException">Thrown when the cancellationToken is cancelled.</exception>
-        public static async Task RunWithInitAsync(this IHost host, CancellationToken cancellationToken = default)
+        public static async Task InitAndRunAsync(this IHost host, CancellationToken cancellationToken = default)
         {
             if (host == null) throw new ArgumentNullException(nameof(host));
 

--- a/src/Extensions.Hosting.AsyncInitialization/Hosting/AsyncInitializationHostExtensions.cs
+++ b/src/Extensions.Hosting.AsyncInitialization/Hosting/AsyncInitializationHostExtensions.cs
@@ -32,5 +32,35 @@ namespace Microsoft.Extensions.Hosting
 
             await rootInitializer.InitializeAsync(cancellationToken);
         }
+
+
+        /// <summary>
+        /// Initializes and runs the application, by first calling all registered async initializers.
+        /// Upon completion, any registered initializers implementing <see cref="IAsyncTeardown"/> are called.
+        /// </summary>
+        /// <param name="host">The host.</param>
+        /// <param name="cancellationToken">Optionally propagates notifications that the operation should be cancelled</param>
+        /// <returns>A task that represents the initialization completion.</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="InvalidOperationException"></exception>
+        /// <exception cref="OperationCanceledException"></exception>
+        public static async Task RunInitAsync(this IHost host, CancellationToken cancellationToken = default)
+        {
+            if (host == null) throw new ArgumentNullException(nameof(host));
+
+            using var scope = host.Services.CreateScope();
+            var rootInitializer = scope.ServiceProvider.GetService<RootInitializer>()
+                ?? throw new InvalidOperationException("The async initialization service isn't registered, register it by calling AddAsyncInitialization() on the service collection or by adding an async initializer.");
+
+            try
+            {
+                await rootInitializer.InitializeAsync(cancellationToken).ConfigureAwait(false);
+                await host.RunAsync(cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                await rootInitializer.TeardownAsync().ConfigureAwait(false);
+            }
+        }
     }
 }

--- a/src/Extensions.Hosting.AsyncInitialization/Hosting/AsyncInitializationHostExtensions.cs
+++ b/src/Extensions.Hosting.AsyncInitialization/Hosting/AsyncInitializationHostExtensions.cs
@@ -18,33 +18,55 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="host">The host.</param>
         /// <param name="cancellationToken">Optionally propagates notifications that the operation should be cancelled</param>
         /// <returns>A task that represents the initialization completion.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the host is null.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the initialization service has not been registered.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the cancellationToken is cancelled.</exception>
         public static async Task InitAsync(this IHost host, CancellationToken cancellationToken = default)
         {
             if (host == null)
                 throw new ArgumentNullException(nameof(host));
 
             using var scope = host.Services.CreateScope();
-            var rootInitializer = scope.ServiceProvider.GetService<RootInitializer?>();
-            if (rootInitializer == null)
-            {
-                throw new InvalidOperationException("The async initialization service isn't registered, register it by calling AddAsyncInitialization() on the service collection or by adding an async initializer.");
-            }
+            var rootInitializer = scope.ServiceProvider.GetService<RootInitializer>()
+                ?? throw new InvalidOperationException("The async initialization service isn't registered, register it by calling AddAsyncInitialization() on the service collection or by adding an async initializer.");
 
-            await rootInitializer.InitializeAsync(cancellationToken);
+            await rootInitializer.InitializeAsync(cancellationToken).ConfigureAwait(false);
         }
 
-
         /// <summary>
-        /// Initializes and runs the application, by first calling all registered async initializers.
-        /// Upon completion, any registered initializers implementing <see cref="IAsyncTeardown"/> are called.
+        /// Performs application teardown by calling all registered async initializers implementing <see cref="IAsyncTeardown"/>.
         /// </summary>
         /// <param name="host">The host.</param>
         /// <param name="cancellationToken">Optionally propagates notifications that the operation should be cancelled</param>
-        /// <returns>A task that represents the initialization completion.</returns>
-        /// <exception cref="ArgumentNullException"></exception>
-        /// <exception cref="InvalidOperationException"></exception>
-        /// <exception cref="OperationCanceledException"></exception>
-        public static async Task RunInitAsync(this IHost host, CancellationToken cancellationToken = default)
+        /// <returns>A task that represents the teardown completion.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the host is null.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the initialization service has not been registered.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the cancellationToken is cancelled.</exception>
+        /// <exception cref="ObjectDisposedException">Thrown when the host has been disposed.</exception>
+        /// <remarks>Make sure not to call this method after the host has terminated, eg. after a call to RunAsync().</remarks>
+        public static async Task TeardownAsync(this IHost host, CancellationToken cancellationToken = default)
+        {
+            if (host == null)
+                throw new ArgumentNullException(nameof(host));
+
+            using var scope = host.Services.CreateScope();
+            var rootInitializer = scope.ServiceProvider.GetService<RootInitializer>()
+                ?? throw new InvalidOperationException("The async initialization service isn't registered, register it by calling AddAsyncInitialization() on the service collection or by adding an async initializer.");
+
+            await rootInitializer.TeardownAsync(cancellationToken).ConfigureAwait(false); 
+        }
+
+        /// <summary>
+        /// Initializes and runs the application, by first calling all registered async initializers.
+        /// After the host terminates, any registered initializers that implement <see cref="IAsyncTeardown"/> are called to perform the teardown.
+        /// </summary>
+        /// <param name="host">The host.</param>
+        /// <param name="cancellationToken">Optionally propagates notifications that the operation should be cancelled</param>
+        /// <returns>A task that represents the run completion.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the host is null.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the initialization service has not been registered.</exception>
+        /// <exception cref="OperationCanceledException">Thrown when the cancellationToken is cancelled.</exception>
+        public static async Task RunWithInitAsync(this IHost host, CancellationToken cancellationToken = default)
         {
             if (host == null) throw new ArgumentNullException(nameof(host));
 

--- a/src/Extensions.Hosting.AsyncInitialization/IAsyncTeardown.cs
+++ b/src/Extensions.Hosting.AsyncInitialization/IAsyncTeardown.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading.Tasks;
+using System.Threading;
+
+namespace Extensions.Hosting.AsyncInitialization
+{
+    /// <summary>
+    /// Represents a type that performs async teardown for types implementing <see cref="IAsyncInitializer"/>
+    /// </summary>
+    public interface IAsyncTeardown : IAsyncInitializer
+    {
+        /// <summary>
+        /// Performs async teardown.
+        /// </summary>
+        /// <param name="cancellationToken">Notifies that the operation should be cancelled</param>
+        /// <returns>A task that represents the teardown completion.</returns>
+        Task TeardownAsync(CancellationToken cancellationToken);
+    }
+}

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationAndRunTests.cs
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationAndRunTests.cs
@@ -150,8 +150,10 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
             A.CallTo(() => initializer.TeardownAsync(CancellationToken.None)).MustHaveHappenedOnceExactly();
         }
 
-        [Fact]
-        public async Task Host_is_disposed_after_successful_run()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Host_is_disposed_after_successful_run(bool forceIDisposableHost)
         {
             var host = CreateHost(services =>
             {
@@ -160,6 +162,9 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
                 services.AddTransient(factory => OutputHelper);
                 services.AddHostedService<TestService>();
             }, true);
+
+            if (forceIDisposableHost) 
+                host = new SyncDisposableHostWrapper(host);
 
             OutputHelper.WriteLine(host is IAsyncDisposable ? "Using IAsyncDisposable Host" : "Using IDisposable Host");
 
@@ -171,8 +176,10 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
             Assert.IsType<ObjectDisposedException>(exception);
         }
 
-        [Fact]
-        public async Task Host_is_disposed_after_failing_teardown()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Host_is_disposed_after_failing_teardown(bool forceIDisposableHost)
         {
             var initializer = A.Fake<IAsyncTeardown>();
             A.CallTo(() => initializer.TeardownAsync(default)).ThrowsAsync(() => new Exception("oops"));
@@ -184,6 +191,9 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
                 services.AddHostedService<TestService>();
             });
 
+            if (forceIDisposableHost)
+                host = new SyncDisposableHostWrapper(host);
+
             OutputHelper.WriteLine(host is IAsyncDisposable ? "Using IAsyncDisposable Host" : "Using IDisposable Host");
 
             var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync());
@@ -194,8 +204,10 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
             Assert.IsType<ObjectDisposedException>(exception);
         }
 
-        [Fact]
-        public async Task Host_is_disposed_after_failing_initializer()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Host_is_disposed_after_failing_initializer(bool forceIDisposableHost)
         {
             var initializer = A.Fake<IAsyncTeardown>();
             A.CallTo(() => initializer.InitializeAsync(default)).ThrowsAsync(() => new Exception("oops"));
@@ -207,6 +219,9 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
                 services.AddHostedService<TestService>();
             });
 
+            if (forceIDisposableHost)
+                host = new SyncDisposableHostWrapper(host);
+
             OutputHelper.WriteLine(host is IAsyncDisposable ? "Using IAsyncDisposable Host" : "Using IDisposable Host");
 
             var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync());
@@ -217,8 +232,10 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
             Assert.IsType<ObjectDisposedException>(exception);
         }
 
-        [Fact]
-        public async Task Host_is_disposed_after_cancellation()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Host_is_disposed_after_cancellation(bool forceIDisposableHost)
         {
             var host = CreateHost(services =>
             {
@@ -226,6 +243,9 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
                 services.AddTransient(factory => OutputHelper);
                 services.AddHostedService<TestService>();
             });
+
+            if (forceIDisposableHost)
+                host = new SyncDisposableHostWrapper(host);
 
             OutputHelper.WriteLine(host is IAsyncDisposable ? "Using IAsyncDisposable Host" : "Using IDisposable Host");
 

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationAndRunTests.cs
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationAndRunTests.cs
@@ -1,26 +1,60 @@
 ﻿using FakeItEasy;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Extensions.Hosting.AsyncInitialization.Tests
 {
     public class AsyncInitializationAndRunTests 
     {
+        private readonly ITestOutputHelper _testOutput;
+        public AsyncInitializationAndRunTests(ITestOutputHelper testOutput)
+        {
+            _testOutput = testOutput;
+        }
+
+        [Fact]
+        public async Task InitAndRunAsync_throws_InvalidOperationException_when_services_are_not_registered()
+        {
+            var host = CreateHost(services => { });
+            var exception = await Record.ExceptionAsync(() => host.InitAsync());
+            Assert.IsType<InvalidOperationException>(exception);
+            Assert.Equal("The async initialization service isn't registered, register it by calling AddAsyncInitialization() on the service collection or by adding an async initializer.", exception.Message);
+        }
+
         [Fact]
         public async Task Initializer_with_teardown_and_scoped_dependency_does_not_fail_on_host_shutdown()
         {
             var host = CreateHost(services =>
             {
-                services.AddScoped<IDisposableDependency, DisposableDependency>();
-                services.AddAsyncInitializer<InitializerWithTearDownAndDisposableDependency>();
-                services.AddHostedService<MyService>();
+                services.AddScoped(sp => A.Fake<IDependency>());
+                services.AddAsyncInitializer<InitializerWithTearDown>();
+                services.AddTransient(factory => _testOutput);
+                services.AddHostedService<TestService>();
             });
             var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync());
-            Assert.IsType<ApplicationException>(exception);
+            Assert.IsType<Exception>(exception);
+            Assert.Equal("host", exception.Message);
+        }
+
+        [Fact]
+        public async Task Initializer_with_teardown_and_scoped_disposable_dependency_does_not_fail_on_host_shutdown()
+        {
+            var host = CreateHost(services =>
+            {
+                services.AddScoped<IDependency,DisposableDependency>();
+                services.AddAsyncInitializer<InitializerWithTearDown>();
+                services.AddTransient(factory => _testOutput);
+                services.AddHostedService<TestService>();
+            });
+            var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync());
+            Assert.IsType<Exception>(exception);
+            Assert.Equal("host", exception.Message);
         }
 
         [Fact]
@@ -32,21 +66,52 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
 
             var host = CreateHost(services =>
             {
-                services.AddScoped<IDisposableDependency, DisposableDependency>();
                 services.AddAsyncInitializer(initializer1);
                 services.AddAsyncInitializer(initializer2);
                 services.AddAsyncInitializer(initializer3);
-                services.AddHostedService<MyService>();
+                services.AddTransient(factory => _testOutput);
+                services.AddHostedService<TestService>();
             });
 
             var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync());
-            Assert.IsType<ApplicationException>(exception);
+            Assert.IsType<Exception>(exception);
+            Assert.Equal("host", exception.Message);
 
             A.CallTo(() => initializer3.TeardownAsync(default)).MustHaveHappenedOnceExactly()
                 .Then(A.CallTo(() => initializer2.TeardownAsync(default)).MustHaveHappenedOnceExactly())
                 .Then(A.CallTo(() => initializer1.TeardownAsync(default)).MustHaveHappenedOnceExactly());
         }
 
+        [Fact]
+        public async Task Cancelled_initializer_skips_host_run_and_calls_teardown()
+        {
+            using var cancellationTokenSource = new CancellationTokenSource();
+            var initializer1 = A.Fake<IAsyncTeardown>();
+            var initializer2 = A.Fake<IAsyncTeardown>();
+            var initializer3 = A.Fake<IAsyncTeardown>();
+
+
+            A.CallTo(() => initializer1.InitializeAsync(A<CancellationToken>._)).Invokes(_ => cancellationTokenSource.Cancel());
+
+            var host = CreateHost(services =>
+            {
+                services.AddAsyncInitializer(initializer1);
+                services.AddAsyncInitializer(initializer2);
+                services.AddAsyncInitializer(initializer3);
+                services.AddTransient(factory => _testOutput);
+                services.AddHostedService<TestService>();
+            });
+
+            var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync(cancellationTokenSource.Token));
+            Assert.IsType<OperationCanceledException>(exception);
+
+            A.CallTo(() => initializer1.InitializeAsync(A<CancellationToken>._)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => initializer2.InitializeAsync(A<CancellationToken>._)).MustNotHaveHappened();
+            A.CallTo(() => initializer3.InitializeAsync(A<CancellationToken>._)).MustNotHaveHappened();
+            A.CallTo(() => initializer1.TeardownAsync(CancellationToken.None)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => initializer2.TeardownAsync(CancellationToken.None)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => initializer3.TeardownAsync(CancellationToken.None)).MustHaveHappenedOnceExactly();
+        }
 
         [Fact]
         public async Task Failing_initializer_skips_host_run_and_calls_teardown()
@@ -56,11 +121,11 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
 
             var host = CreateHost(services =>
             {
-                services.AddScoped<IDisposableDependency, DisposableDependency>();
                 services.AddAsyncInitializer(initializer);
-                services.AddHostedService<MyService>();
+                services.AddTransient(factory => _testOutput);
+                services.AddHostedService<TestService>();
             });
-
+            
             var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync());
             Assert.IsType<Exception>(exception);
             Assert.Equal("oops", exception.Message);
@@ -70,19 +135,98 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
         }
 
         [Fact]
+        public async Task Host_is_disposed_after_successful_run()
+        {
+            var host = CreateHost(services =>
+            {
+                services.AddScoped<IDependency, DisposableDependency>();
+                services.AddAsyncInitializer<InitializerWithTearDown>();
+                services.AddTransient(factory => _testOutput);
+                services.AddHostedService<TestService>();
+            }, true);
+
+            var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync());
+            Assert.IsType<Exception>(exception);
+            Assert.Equal("host", exception.Message);
+
+            exception = Record.Exception(() => host.Services.CreateScope());
+            Assert.IsType<ObjectDisposedException>(exception);
+        }
+
+        [Fact]
+        public async Task Host_is_disposed_after_failing_teardown()
+        {
+            var initializer = A.Fake<IAsyncTeardown>();
+            A.CallTo(() => initializer.TeardownAsync(default)).ThrowsAsync(() => new Exception("oops"));
+
+            var host = CreateHost(services =>
+            {
+                services.AddAsyncInitializer(initializer);
+                services.AddTransient(factory => _testOutput);
+                services.AddHostedService<TestService>();
+            });
+
+            var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync());
+            Assert.IsType<Exception>(exception);
+            Assert.Equal("oops", exception.Message);
+
+            exception = Record.Exception(() => host.Services.CreateScope());
+            Assert.IsType<ObjectDisposedException>(exception);
+        }
+
+        [Fact]
+        public async Task Host_is_disposed_after_failing_initializer()
+        {
+            var initializer = A.Fake<IAsyncTeardown>();
+            A.CallTo(() => initializer.InitializeAsync(default)).ThrowsAsync(() => new Exception("oops"));
+
+            var host = CreateHost(services =>
+            {
+                services.AddAsyncInitializer(initializer);
+                services.AddTransient(factory => _testOutput);
+                services.AddHostedService<TestService>();
+            });
+
+            var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync());
+            Assert.IsType<Exception>(exception);
+            Assert.Equal("oops", exception.Message);
+
+            exception = Record.Exception(() => host.Services.CreateScope());
+            Assert.IsType<ObjectDisposedException>(exception);
+        }
+
+        [Fact]
+        public async Task Host_is_disposed_after_cancellation()
+        {
+            var host = CreateHost(services =>
+            {
+                services.AddAsyncInitializer(sp => A.Fake<IAsyncTeardown>());
+                services.AddTransient(factory => _testOutput);
+                services.AddHostedService<TestService>();
+            });
+            
+            var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync(new CancellationToken(true)));
+            Assert.IsType<OperationCanceledException>(exception);
+
+            exception = Record.Exception(() => host.Services.CreateScope());
+            Assert.IsType<ObjectDisposedException>(exception);
+        }
+
+        [Fact]
         public async Task Single_initializer_with_teardown_is_called()
         {
             var initializer = A.Fake<IAsyncTeardown>();
 
             var host = CreateHost(services =>
             {
-                services.AddScoped<IDisposableDependency, DisposableDependency>();
                 services.AddAsyncInitializer(initializer);
-                services.AddHostedService<MyService>();
+                services.AddTransient(factory => _testOutput);
+                services.AddHostedService<TestService>();
             });
 
             var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync());
-            Assert.IsType<ApplicationException>(exception);
+            Assert.IsType<Exception>(exception);
+            Assert.Equal("host", exception.Message);
 
             A.CallTo(() => initializer.InitializeAsync(CancellationToken.None)).MustHaveHappenedOnceExactly();
             A.CallTo(() => initializer.TeardownAsync(CancellationToken.None)).MustHaveHappenedOnceExactly();
@@ -100,83 +244,107 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
                 ))
                 .Build();
 
+        private static IHost CreateWebHost(Action<IServiceCollection> configureServices, bool validateScopes = false)
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.Host
+                .ConfigureServices(configureServices)
+                .UseServiceProviderFactory(new DefaultServiceProviderFactory(
+                    new ServiceProviderOptions
+                    {
+                        ValidateScopes = validateScopes
+                    }
+                ));
+            return builder.Build();
+        }
+
         public interface IDependency
         {
         }
 
-       
-        public class InitializerWithTearDown : IAsyncTeardown
-        {
-            // ReSharper disable once NotAccessedField.Local
-            private readonly IDependency _dependency;
-
-            public InitializerWithTearDown(IDependency dependency) 
-            {
-                _dependency = dependency;
-            }
-
-            public Task InitializeAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-
-            public Task TeardownAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-        }
-
-
-        public interface IDisposableDependency : IDisposable
+        public interface IDisposableDependency : IDependency, IDisposable
         {
             IServiceScope SomeMethod();
         }
 
-        public class DisposableDependency : IDisposableDependency
+        public class InitializerWithTearDown : IAsyncTeardown
         {
-            public DisposableDependency(IServiceProvider serviceProvider)
-            {
-                ServiceProvider = serviceProvider;
-            }
+            // ReSharper disable once NotAccessedField.Local
+            private readonly IDependency _dependency;
+            private readonly ITestOutputHelper _output;
 
-            public IServiceProvider ServiceProvider { get; private set; }
-
-            public void Dispose() { }
-
-            public IServiceScope SomeMethod()
-            {
-                return ServiceProvider.CreateScope();
-            }
-        }
-
-        public class MyService : BackgroundService
-        {
-            private readonly IDisposableDependency _dependency;
-            public MyService(IDisposableDependency dependency) 
-            {
-                _dependency = dependency ?? throw new ArgumentNullException(nameof(dependency));
-            }
-
-            protected override Task ExecuteAsync(CancellationToken stoppingToken)
-            {
-                throw new ApplicationException();
-            }
-        }
-
-
-        public class InitializerWithTearDownAndDisposableDependency : IAsyncTeardown
-        {
-            private readonly IDisposableDependency _dependency;
-            public InitializerWithTearDownAndDisposableDependency(IDisposableDependency dependency)
+            public InitializerWithTearDown(IDependency dependency, ITestOutputHelper output) 
             {
                 _dependency = dependency;
+                _output = output;
             }
+
             public Task InitializeAsync(CancellationToken cancellationToken)
             {
-                _= _dependency.SomeMethod();
+                if (_dependency is IDisposableDependency dep)
+                {
+                    _= dep.SomeMethod();
+                    _output.WriteLine("InitializeAsync Call to DisposableDependency");
+                }
                 return Task.CompletedTask;
             }
 
             public Task TeardownAsync(CancellationToken cancellationToken)
             {
-                _= _dependency.SomeMethod();
+                if (_dependency is IDisposableDependency dep)
+                {
+                    _= dep.SomeMethod();
+                    _output.WriteLine("TeardownAsync Call to DisposableDependency");
+                }
                 return Task.CompletedTask;
             }
         }
 
+
+       
+
+        public class DisposableDependency : IDisposableDependency
+        {
+            private readonly ITestOutputHelper _output;
+           
+            public DisposableDependency(IServiceProvider serviceProvider, ITestOutputHelper output)
+            {
+                ServiceProvider = serviceProvider;
+                _output = output;
+            }
+
+            public IServiceProvider ServiceProvider { get; private set; }
+
+            public IServiceScope SomeMethod()
+            {
+                return ServiceProvider.CreateScope();
+            }
+
+            public void Dispose()
+            {
+                _output.WriteLine("Disposing DisposableDependency");
+            }
+        }
+
+        public class TestService : BackgroundService
+        {
+            private readonly ITestOutputHelper _output;
+            public TestService(ITestOutputHelper output) 
+            {
+                _output = output;
+            }
+
+            protected override Task ExecuteAsync(CancellationToken stoppingToken)
+            {
+                //Throwing exception to stop service
+                throw new Exception("host");
+            }
+
+            public override void Dispose()
+            {
+                _output.WriteLine("Disposing TestService");
+                base.Dispose();
+            }
+        }
     }
 }

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationAndRunTests.cs
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationAndRunTests.cs
@@ -1,0 +1,182 @@
+﻿using FakeItEasy;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Extensions.Hosting.AsyncInitialization.Tests
+{
+    public class AsyncInitializationAndRunTests 
+    {
+        [Fact]
+        public async Task Initializer_with_teardown_and_scoped_dependency_does_not_fail_on_host_shutdown()
+        {
+            var host = CreateHost(services =>
+            {
+                services.AddScoped<IDisposableDependency, DisposableDependency>();
+                services.AddAsyncInitializer<InitializerWithTearDownAndDisposableDependency>();
+                services.AddHostedService<MyService>();
+            });
+            var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync());
+            Assert.IsType<ApplicationException>(exception);
+        }
+
+        [Fact]
+        public async Task Multiple_initializers_with_teardown_are_called_in_reverse_order()
+        {
+            var initializer1 = A.Fake<IAsyncTeardown>();
+            var initializer2 = A.Fake<IAsyncTeardown>();
+            var initializer3 = A.Fake<IAsyncTeardown>();
+
+            var host = CreateHost(services =>
+            {
+                services.AddScoped<IDisposableDependency, DisposableDependency>();
+                services.AddAsyncInitializer(initializer1);
+                services.AddAsyncInitializer(initializer2);
+                services.AddAsyncInitializer(initializer3);
+                services.AddHostedService<MyService>();
+            });
+
+            var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync());
+            Assert.IsType<ApplicationException>(exception);
+
+            A.CallTo(() => initializer3.TeardownAsync(default)).MustHaveHappenedOnceExactly()
+                .Then(A.CallTo(() => initializer2.TeardownAsync(default)).MustHaveHappenedOnceExactly())
+                .Then(A.CallTo(() => initializer1.TeardownAsync(default)).MustHaveHappenedOnceExactly());
+        }
+
+
+        [Fact]
+        public async Task Failing_initializer_skips_host_run_and_calls_teardown()
+        {
+            var initializer = A.Fake<IAsyncTeardown>();
+            A.CallTo(() => initializer.InitializeAsync(default)).ThrowsAsync(() => new Exception("oops"));
+
+            var host = CreateHost(services =>
+            {
+                services.AddScoped<IDisposableDependency, DisposableDependency>();
+                services.AddAsyncInitializer(initializer);
+                services.AddHostedService<MyService>();
+            });
+
+            var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync());
+            Assert.IsType<Exception>(exception);
+            Assert.Equal("oops", exception.Message);
+
+            A.CallTo(() => initializer.InitializeAsync(CancellationToken.None)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => initializer.TeardownAsync(CancellationToken.None)).MustHaveHappenedOnceExactly();
+        }
+
+        [Fact]
+        public async Task Single_initializer_with_teardown_is_called()
+        {
+            var initializer = A.Fake<IAsyncTeardown>();
+
+            var host = CreateHost(services =>
+            {
+                services.AddScoped<IDisposableDependency, DisposableDependency>();
+                services.AddAsyncInitializer(initializer);
+                services.AddHostedService<MyService>();
+            });
+
+            var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync());
+            Assert.IsType<ApplicationException>(exception);
+
+            A.CallTo(() => initializer.InitializeAsync(CancellationToken.None)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => initializer.TeardownAsync(CancellationToken.None)).MustHaveHappenedOnceExactly();
+        }
+
+
+        private static IHost CreateHost(Action<IServiceCollection> configureServices, bool validateScopes = false) =>
+            new HostBuilder()
+                .ConfigureServices(configureServices)
+                .UseServiceProviderFactory(new DefaultServiceProviderFactory(
+                    new ServiceProviderOptions
+                    {
+                        ValidateScopes = validateScopes
+                    }
+                ))
+                .Build();
+
+        public interface IDependency
+        {
+        }
+
+       
+        public class InitializerWithTearDown : IAsyncTeardown
+        {
+            // ReSharper disable once NotAccessedField.Local
+            private readonly IDependency _dependency;
+
+            public InitializerWithTearDown(IDependency dependency) 
+            {
+                _dependency = dependency;
+            }
+
+            public Task InitializeAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+            public Task TeardownAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        }
+
+
+        public interface IDisposableDependency : IDisposable
+        {
+            IServiceScope SomeMethod();
+        }
+
+        public class DisposableDependency : IDisposableDependency
+        {
+            public DisposableDependency(IServiceProvider serviceProvider)
+            {
+                ServiceProvider = serviceProvider;
+            }
+
+            public IServiceProvider ServiceProvider { get; private set; }
+
+            public void Dispose() { }
+
+            public IServiceScope SomeMethod()
+            {
+                return ServiceProvider.CreateScope();
+            }
+        }
+
+        public class MyService : BackgroundService
+        {
+            private readonly IDisposableDependency _dependency;
+            public MyService(IDisposableDependency dependency) 
+            {
+                _dependency = dependency ?? throw new ArgumentNullException(nameof(dependency));
+            }
+
+            protected override Task ExecuteAsync(CancellationToken stoppingToken)
+            {
+                throw new ApplicationException();
+            }
+        }
+
+
+        public class InitializerWithTearDownAndDisposableDependency : IAsyncTeardown
+        {
+            private readonly IDisposableDependency _dependency;
+            public InitializerWithTearDownAndDisposableDependency(IDisposableDependency dependency)
+            {
+                _dependency = dependency;
+            }
+            public Task InitializeAsync(CancellationToken cancellationToken)
+            {
+                _= _dependency.SomeMethod();
+                return Task.CompletedTask;
+            }
+
+            public Task TeardownAsync(CancellationToken cancellationToken)
+            {
+                _= _dependency.SomeMethod();
+                return Task.CompletedTask;
+            }
+        }
+
+    }
+}

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationAndRunTests.cs
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationAndRunTests.cs
@@ -189,10 +189,7 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
                 services.AddAsyncInitializer(initializer);
                 services.AddTransient(factory => OutputHelper);
                 services.AddHostedService<TestService>();
-            });
-
-            if (forceIDisposableHost)
-                host = new SyncDisposableHostWrapper(host);
+            }, forceIDisposableHost: forceIDisposableHost);
 
             OutputHelper.WriteLine(host is IAsyncDisposable ? "Using IAsyncDisposable Host" : "Using IDisposable Host");
 
@@ -217,10 +214,7 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
                 services.AddAsyncInitializer(initializer);
                 services.AddTransient(factory => OutputHelper);
                 services.AddHostedService<TestService>();
-            });
-
-            if (forceIDisposableHost)
-                host = new SyncDisposableHostWrapper(host);
+            }, forceIDisposableHost: forceIDisposableHost);
 
             OutputHelper.WriteLine(host is IAsyncDisposable ? "Using IAsyncDisposable Host" : "Using IDisposable Host");
 
@@ -242,10 +236,7 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
                 services.AddAsyncInitializer(sp => A.Fake<IAsyncTeardown>());
                 services.AddTransient(factory => OutputHelper);
                 services.AddHostedService<TestService>();
-            });
-
-            if (forceIDisposableHost)
-                host = new SyncDisposableHostWrapper(host);
+            }, forceIDisposableHost: forceIDisposableHost);
 
             OutputHelper.WriteLine(host is IAsyncDisposable ? "Using IAsyncDisposable Host" : "Using IDisposable Host");
 

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationAndRunTests.cs
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationAndRunTests.cs
@@ -57,6 +57,21 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
         }
 
         [Fact]
+        public async Task Initializer_with_teardown_and_singleton_disposable_dependency_does_not_fail_on_host_shutdown()
+        {
+            var host = CreateHost(services =>
+            {
+                services.AddSingleton<IDependency, DisposableDependency>();
+                services.AddAsyncInitializer<InitializerWithTearDown>();
+                services.AddTransient(factory => _testOutput);
+                services.AddHostedService<TestService>();
+            });
+            var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync());
+            Assert.IsType<Exception>(exception);
+            Assert.Equal("host", exception.Message);
+        }
+
+        [Fact]
         public async Task Multiple_initializers_with_teardown_are_called_in_reverse_order()
         {
             var initializer1 = A.Fake<IAsyncTeardown>();

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationAndRunTests.cs
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationAndRunTests.cs
@@ -1,5 +1,4 @@
 ﻿using FakeItEasy;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System;
@@ -244,19 +243,7 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
                 ))
                 .Build();
 
-        private static IHost CreateWebHost(Action<IServiceCollection> configureServices, bool validateScopes = false)
-        {
-            var builder = WebApplication.CreateBuilder();
-            builder.Host
-                .ConfigureServices(configureServices)
-                .UseServiceProviderFactory(new DefaultServiceProviderFactory(
-                    new ServiceProviderOptions
-                    {
-                        ValidateScopes = validateScopes
-                    }
-                ));
-            return builder.Build();
-        }
+        
 
         public interface IDependency
         {

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationAndRunTests.cs
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationAndRunTests.cs
@@ -161,6 +161,8 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
                 services.AddHostedService<TestService>();
             }, true);
 
+            OutputHelper.WriteLine(host is IAsyncDisposable ? "Using IAsyncDisposable Host" : "Using IDisposable Host");
+
             var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync());
             Assert.IsType<Exception>(exception);
             Assert.Equal("host", exception.Message);
@@ -181,6 +183,8 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
                 services.AddTransient(factory => OutputHelper);
                 services.AddHostedService<TestService>();
             });
+
+            OutputHelper.WriteLine(host is IAsyncDisposable ? "Using IAsyncDisposable Host" : "Using IDisposable Host");
 
             var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync());
             Assert.IsType<Exception>(exception);
@@ -203,6 +207,8 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
                 services.AddHostedService<TestService>();
             });
 
+            OutputHelper.WriteLine(host is IAsyncDisposable ? "Using IAsyncDisposable Host" : "Using IDisposable Host");
+
             var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync());
             Assert.IsType<Exception>(exception);
             Assert.Equal("oops", exception.Message);
@@ -220,7 +226,9 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
                 services.AddTransient(factory => OutputHelper);
                 services.AddHostedService<TestService>();
             });
-            
+
+            OutputHelper.WriteLine(host is IAsyncDisposable ? "Using IAsyncDisposable Host" : "Using IDisposable Host");
+
             var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync(new CancellationToken(true)));
             Assert.IsType<OperationCanceledException>(exception);
 

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationTests.cs
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationTests.cs
@@ -5,6 +5,7 @@ using FakeItEasy;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
+using static Extensions.Hosting.AsyncInitialization.Tests.CommonTestTypes;
 
 namespace Extensions.Hosting.AsyncInitialization.Tests
 {
@@ -126,34 +127,6 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
             var exception = await Record.ExceptionAsync(() => host.InitAsync());
             Assert.IsType<InvalidOperationException>(exception);
             Assert.Equal("The async initialization service isn't registered, register it by calling AddAsyncInitialization() on the service collection or by adding an async initializer.", exception.Message);
-        }
-
-        private static IHost CreateHost(Action<IServiceCollection> configureServices, bool validateScopes = false) =>
-            new HostBuilder()
-                .ConfigureServices(configureServices)
-                .UseServiceProviderFactory(new DefaultServiceProviderFactory(
-                    new ServiceProviderOptions
-                    {
-                        ValidateScopes = validateScopes
-                    }
-                ))
-                .Build();
-
-        public interface IDependency
-        {
-        }
-
-        public class Initializer : IAsyncInitializer
-        {
-            // ReSharper disable once NotAccessedField.Local
-            private readonly IDependency _dependency;
-
-            public Initializer(IDependency dependency)
-            {
-                _dependency = dependency;
-            }
-
-            public Task InitializeAsync(CancellationToken cancellationToken) => Task.CompletedTask;
         }
     }
 }

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/CommonTestTypes.cs
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/CommonTestTypes.cs
@@ -1,0 +1,127 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.Threading.Tasks;
+using System.Threading;
+using Xunit.Abstractions;
+
+namespace Extensions.Hosting.AsyncInitialization.Tests
+{
+    public class CommonTestTypes
+    {
+
+        public interface IDependency
+        {
+
+        }
+
+        public interface IDisposableDependency : IDependency, IDisposable
+        {
+            IServiceScope SomeMethod();
+        }
+
+
+        public class Initializer : IAsyncInitializer
+        {
+            // ReSharper disable once NotAccessedField.Local
+            private readonly IDependency _dependency;
+
+            public Initializer(IDependency dependency)
+            {
+                _dependency = dependency;
+            }
+
+            public Task InitializeAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        }
+
+        public class InitializerWithTearDown : IAsyncTeardown
+        {
+            // ReSharper disable once NotAccessedField.Local
+            private readonly IDependency _dependency;
+            private readonly ITestOutputHelper _output;
+
+            public InitializerWithTearDown(IDependency dependency, ITestOutputHelper output)
+            {
+                _dependency = dependency;
+                _output = output;
+            }
+
+            public Task InitializeAsync(CancellationToken cancellationToken)
+            {
+                if (_dependency is IDisposableDependency dep)
+                {
+                    _= dep.SomeMethod();
+                    _output.WriteLine("InitializeAsync Call to DisposableDependency");
+                }
+                return Task.CompletedTask;
+            }
+
+            public Task TeardownAsync(CancellationToken cancellationToken)
+            {
+                if (_dependency is IDisposableDependency dep)
+                {
+                    _= dep.SomeMethod();
+                    _output.WriteLine("TeardownAsync Call to DisposableDependency");
+                }
+                return Task.CompletedTask;
+            }
+        }
+
+
+        public class DisposableDependency : IDisposableDependency
+        {
+            private readonly ITestOutputHelper _output;
+
+            public DisposableDependency(IServiceProvider serviceProvider, ITestOutputHelper output)
+            {
+                ServiceProvider = serviceProvider;
+                _output = output;
+            }
+
+            public IServiceProvider ServiceProvider { get; private set; }
+
+            public IServiceScope SomeMethod()
+            {
+                return ServiceProvider.CreateScope();
+            }
+
+            public void Dispose()
+            {
+                _output.WriteLine("Disposing DisposableDependency");
+            }
+        }
+
+        public class TestService : BackgroundService
+        {
+            private readonly ITestOutputHelper _output;
+            public TestService(ITestOutputHelper output)
+            {
+                _output = output;
+            }
+
+            protected override Task ExecuteAsync(CancellationToken stoppingToken)
+            {
+                //Throwing exception to stop service
+                throw new Exception("host");
+            }
+
+            public override void Dispose()
+            {
+                _output.WriteLine("Disposing TestService");
+                base.Dispose();
+            }
+        }
+
+        public static IHost CreateHost(Action<IServiceCollection> configureServices, bool validateScopes = false) =>
+          new HostBuilder()
+              .ConfigureServices(configureServices)
+              .UseServiceProviderFactory(new DefaultServiceProviderFactory(
+                  new ServiceProviderOptions
+                  {
+                      ValidateScopes = validateScopes
+                  }
+              ))
+              .Build();
+
+    }
+}

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/CommonTestTypes.cs
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/CommonTestTypes.cs
@@ -115,8 +115,8 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
         public class SyncDisposableHostWrapper : IHost, IDisposable
         {
             private readonly IHost _host;
-            public SyncDisposableHostWrapper(IHost host) 
-            { 
+            public SyncDisposableHostWrapper(IHost host)
+            {
                 _host = host ?? throw new ArgumentNullException(nameof(host));
             }
 
@@ -138,8 +138,9 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
             }
         }
 
-        public static IHost CreateHost(Action<IServiceCollection> configureServices, bool validateScopes = false) =>
-          new HostBuilder()
+        public static IHost CreateHost(Action<IServiceCollection> configureServices, bool validateScopes = false, bool forceIDisposableHost = false)
+        {
+            var host = new HostBuilder()
               .ConfigureServices(configureServices)
               .UseServiceProviderFactory(new DefaultServiceProviderFactory(
                   new ServiceProviderOptions
@@ -148,6 +149,9 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
                   }
               ))
               .Build();
+
+            return forceIDisposableHost ? new SyncDisposableHostWrapper(host) : host;
+        }
 
     }
 }

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/CommonTestTypes.cs
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/CommonTestTypes.cs
@@ -112,6 +112,32 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
             }
         }
 
+        public class SyncDisposableHostWrapper : IHost, IDisposable
+        {
+            private readonly IHost _host;
+            public SyncDisposableHostWrapper(IHost host) 
+            { 
+                _host = host ?? throw new ArgumentNullException(nameof(host));
+            }
+
+            public IServiceProvider Services => _host.Services;
+
+            public void Dispose()
+            {
+                _host.Dispose();
+            }
+
+            public Task StartAsync(CancellationToken cancellationToken = default)
+            {
+                return _host.StartAsync(cancellationToken);
+            }
+
+            public Task StopAsync(CancellationToken cancellationToken = default)
+            {
+                return _host.StopAsync(cancellationToken);
+            }
+        }
+
         public static IHost CreateHost(Action<IServiceCollection> configureServices, bool validateScopes = false) =>
           new HostBuilder()
               .ConfigureServices(configureServices)

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/Extensions.Hosting.AsyncInitialization.Tests.csproj
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/Extensions.Hosting.AsyncInitialization.Tests.csproj
@@ -5,19 +5,23 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <Configurations>Debug;Release;ReleaseLegacyHosting</Configurations>
+		<MSEHostingVersion Condition="'$(Configuration)' == 'ReleaseLegacyHosting'">2.1.0</MSEHostingVersion>
+		<MSEHostingVersion Condition="'$(Configuration)' != 'ReleaseLegacyHosting'">6.0.0</MSEHostingVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="7.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		
+		<ItemGroup>
+				<PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MSEHostingVersion)" />
+				<PackageReference Include="FakeItEasy" Version="7.4.0" />
+				<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+        <PackageReference Include="xunit" Version="2.5.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+						<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-
+		
   <ItemGroup>
     <ProjectReference Include="..\..\src\Extensions.Hosting.AsyncInitialization\Extensions.Hosting.AsyncInitialization.csproj" />
   </ItemGroup>

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/Extensions.Hosting.AsyncInitialization.Tests.csproj
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/Extensions.Hosting.AsyncInitialization.Tests.csproj
@@ -22,8 +22,4 @@
     <ProjectReference Include="..\..\src\Extensions.Hosting.AsyncInitialization\Extensions.Hosting.AsyncInitialization.csproj" />
   </ItemGroup>
 
-		<ItemGroup>
-				<FrameworkReference Include="Microsoft.AspNetCore.App" />
-		</ItemGroup>
-
 </Project>

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/Extensions.Hosting.AsyncInitialization.Tests.csproj
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/Extensions.Hosting.AsyncInitialization.Tests.csproj
@@ -5,14 +5,11 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <Configurations>Debug;Release;ReleaseLegacyHosting</Configurations>
-		<MSEHostingVersion Condition="'$(Configuration)' == 'ReleaseLegacyHosting'">2.1.0</MSEHostingVersion>
-		<MSEHostingVersion Condition="'$(Configuration)' != 'ReleaseLegacyHosting'">6.0.0</MSEHostingVersion>
   </PropertyGroup>
 
 		
 		<ItemGroup>
-				<PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MSEHostingVersion)" />
+				<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
 				<PackageReference Include="FakeItEasy" Version="7.4.0" />
 				<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
         <PackageReference Include="xunit" Version="2.5.0" />

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/Extensions.Hosting.AsyncInitialization.Tests.csproj
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/Extensions.Hosting.AsyncInitialization.Tests.csproj
@@ -22,4 +22,8 @@
     <ProjectReference Include="..\..\src\Extensions.Hosting.AsyncInitialization\Extensions.Hosting.AsyncInitialization.csproj" />
   </ItemGroup>
 
+		<ItemGroup>
+				<FrameworkReference Include="Microsoft.AspNetCore.App" />
+		</ItemGroup>
+
 </Project>

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/Extensions.Hosting.AsyncInitialization.Tests.csproj
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/Extensions.Hosting.AsyncInitialization.Tests.csproj
@@ -1,26 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
-
+		<PropertyGroup>
+				<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+				<LangVersion>latest</LangVersion>
+				<Nullable>enable</Nullable>
+				<IsPackable>false</IsPackable>
+		</PropertyGroup>
 		
 		<ItemGroup>
 				<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
 				<PackageReference Include="FakeItEasy" Version="7.4.0" />
 				<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-        <PackageReference Include="xunit" Version="2.5.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+				<PackageReference Include="xunit" Version="2.5.0" />
+				<PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
 						<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-		
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Extensions.Hosting.AsyncInitialization\Extensions.Hosting.AsyncInitialization.csproj" />
-  </ItemGroup>
+						<PrivateAssets>all</PrivateAssets>
+				</PackageReference>
+		</ItemGroup>
 
+		<ItemGroup>
+				<ProjectReference Include="..\..\src\Extensions.Hosting.AsyncInitialization\Extensions.Hosting.AsyncInitialization.csproj" />
+		</ItemGroup>
 </Project>

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/Extensions.Hosting.AsyncInitialization.Tests.csproj
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/Extensions.Hosting.AsyncInitialization.Tests.csproj
@@ -5,7 +5,7 @@
 				<Nullable>enable</Nullable>
 				<IsPackable>false</IsPackable>
 		</PropertyGroup>
-		
+
 		<ItemGroup>
 				<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
 				<PackageReference Include="FakeItEasy" Version="7.4.0" />

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/Extensions.Hosting.AsyncInitialization.Tests.csproj
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/Extensions.Hosting.AsyncInitialization.Tests.csproj
@@ -1,23 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-		<PropertyGroup>
-				<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-				<LangVersion>latest</LangVersion>
-				<Nullable>enable</Nullable>
-				<IsPackable>false</IsPackable>
-		</PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
 
-		<ItemGroup>
-				<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-				<PackageReference Include="FakeItEasy" Version="7.4.0" />
-				<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-				<PackageReference Include="xunit" Version="2.5.0" />
-				<PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
-						<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-						<PrivateAssets>all</PrivateAssets>
-				</PackageReference>
-		</ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+        <PackageReference Include="FakeItEasy" Version="7.4.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+        <PackageReference Include="xunit" Version="2.5.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
 
-		<ItemGroup>
-				<ProjectReference Include="..\..\src\Extensions.Hosting.AsyncInitialization\Extensions.Hosting.AsyncInitialization.csproj" />
-		</ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Extensions.Hosting.AsyncInitialization\Extensions.Hosting.AsyncInitialization.csproj" />
+    </ItemGroup>
 </Project>

--- a/tools/build/build.csproj
+++ b/tools/build/build.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
+    <Configurations>Debug;Release;ReleaseLegacyHosting</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/build/build.csproj
+++ b/tools/build/build.csproj
@@ -1,14 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net7.0</TargetFramework>
+    </PropertyGroup>
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Bullseye" Version="4.2.1" />
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
-    <PackageReference Include="SimpleExec" Version="11.0.0" />
-  </ItemGroup>
-
+    <ItemGroup>
+        <PackageReference Include="Bullseye" Version="4.2.1" />
+        <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
+        <PackageReference Include="SimpleExec" Version="11.0.0" />
+    </ItemGroup>
 </Project>

--- a/tools/build/build.csproj
+++ b/tools/build/build.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
-    <Configurations>Debug;Release;ReleaseLegacyHosting</Configurations>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi @thomaslevesque 
Sorry, I had to close the old pull request to get things straightend out.
And thanks for updating the targets!
Attached, please find an updated version of `InitAndRunAsync()`.

The method now no longer holds a reference to the RootInitializer, allowing any dependencies that `IAsyncInitializer` instances may hold to be disposed based on their lifetime.

Cheers
Alexander