### PR TITLE
Update README for InitAndRunAsync and add parameter to specify initializer lifetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ await using (var host = CreateHostBuilder(args).Build())
 
 The `InitAndRunAsync`, `InitAsync` and `TeardownAsync` all support passing a cancellation token to abort execution if needed. Cancellation will be propagated to the initializers.
 
-In the following example, execution (including initialization and teardown) will be aborted when `Ctrl + C` keys are pressed :
+In the following example, execution (including initialization, but not teardown) will be aborted when `Ctrl + C` keys are pressed :
 ```csharp
 public static async Task Main(string[] args)
 {
@@ -141,6 +141,10 @@ public static async Task Main(string[] args)
 }
 ```
 
+As mentioned above, when using `InitAndRunAsync`, the cancellation token will *not* be passed to the teardown. This is because when your application is stopped, you typically still want the teardown to occur. Instead, teardown will run with a default timeout of 10 seconds (you can also specify a timeout explicitly).
+
+If you don't want this behavior, you can manually call `InitAsync` and `TeardownAsync` as explained in the previous section.
+
 ### Migration from 2.x or earlier
 
 If you were already using this library prior to version 3.x, your code would typically look like this:
@@ -150,4 +154,4 @@ await host.InitAsync();
 await host.RunAsync();
 ```
 
-This will still work without changes. Just keep in mind that, as explained in the previous section, adding a call to `host.TeardownAsync()` after `host.RunAsync()` will not work. If you need teardown, the simplest way is to remove the explicit call to `InitAsync`, and call `InitAndRunAsync` instead of `RunAsync`.
+This will still work without changes. Just keep in mind that, as explained in the previous section, adding a call to `host.TeardownAsync()` after `host.RunAsync()` *will not work*. If you need teardown, the simplest way is to remove the explicit call to `InitAsync`, and call `InitAndRunAsync` instead of `RunAsync`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A simple helper to perform async application initialization for the generic host in .NET 6.0 or higher (e.g. in ASP.NET Core apps).
 
-## Usage
+## Basic usage
 
 1. Install the [Extensions.Hosting.AsyncInitialization](https://www.nuget.org/packages/Extensions.Hosting.AsyncInitialization/) NuGet package:
 
@@ -42,21 +42,20 @@ A simple helper to perform async application initialization for the generic host
 3. Register your initializer(s) in the same place as other services:
 
     ```csharp
-        services.AddAsyncInitializer<MyAppInitializer>();
+    services.AddAsyncInitializer<MyAppInitializer>();
     ```
 
-4. In the `Program` class, make the `Main` method async and change its code to initialize the host before running it:
+4. In the `Program` class, replace the call to `host.RunAsync()` with `host.InitAndRunAsync()`:
 
     ```csharp
     public static async Task Main(string[] args)
     {
         var host = CreateHostBuilder(args).Build();
-        await host.InitAsync();
-        await host.RunAsync();
+        await host.InitAndRunAsync();
     }
     ```
 
-    You can also pass a `CancellationToken` in order to propagate notifications to cancel the initialization if needed.
+    You can also pass a `CancellationToken` in order to propagate notifications to abort execution if needed. Cancellation will be propagated to the initializers.
 
     In the following example, the initialization will be cancelled when `Ctrl + C` keys are pressed :
     ```csharp
@@ -68,10 +67,85 @@ A simple helper to perform async application initialization for the generic host
         Console.CancelKeyPress += (source, args) => cancellationTokenSource.Cancel();
 
         var host = CreateHostBuilder(args).Build();
-
-        await host.InitAsync(cancellationTokenSource.Token);
-        await host.RunAsync();
+        await host.InitAndRunAsync(cancellationTokenSource.Token);
     }
     ```
 
 This will run each initializer, in the order in which they were registered.
+
+## Teardown
+
+In addition to initialization, this library also supports performing cleanup tasks when the app terminates. To use this, make your initializer implement `IAsyncTeardown`, and implement the `TeardownAsync` method:
+
+
+```csharp
+public class MyAppInitializer : IAsyncTeardown
+{
+    public MyAppInitializer(IFoo foo, IBar bar)
+    {
+        ...
+    }
+
+    public async Task InitializeAsync(CancellationToken cancellationToken)
+    {
+        // Initialization code here
+    }
+
+    public async Task TeardownAsync(CancellationToken cancellationToken)
+    {
+        // Cleanup code here
+    }
+}
+```
+
+When you run the application with `InitAndRunAsync`, each initializer that supports teardown will be invoked in reverse registration order, i.e.:
+
+- initializer 1 performs initialization
+- initializer 2 performs initialization
+- application runs
+- initializer 2 performs teardown
+- initializer 1 performs teardown
+
+## Lifetime and state considerations
+
+When you create an initializer that also performs teardown, keep in mind that it will actually be resolved twice:
+- once for initialization
+- once for teardown
+
+Initialization and teardown each runs in its own service provider scope. This means that a different instance of your initializer will be used for initialization and teardown, so your initializer cannot keep state between initialization and teardown, unless it's registered as a singleton.
+
+If you do register your initializer as a singleton, keep in mind that it must not depend on any scoped service, otherwise the scoped service will live for the whole lifetime of the application; this is an anti-pattern known as [captive dependency](https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection-guidelines#captive-dependency).
+
+## Advanced usage
+
+If, for some reason, you need more control over the application execution process, you can manually call the `InitAsync` and `TeardownAsync` methods on the host. If you do that, keep in mind that `TeardownAsync` cannot be called after `host.RunAsync()` completes, because the host will already have been disposed:
+
+```csharp
+// DO NOT DO THIS
+await host.InitAsync();
+await host.RunAsync();
+await host.TeardownAsync(); // Will fail because RunAsync disposed the host
+```
+
+So you will need to manually call `StartAsync` and `WaitForShutdownAsync`, and call `TeardownAsync` _before_ you dispose the host:
+
+```csharp
+await using (var host = CreateHostBuilder(args).Build())
+{
+    await host.InitAsync();
+    await host.StartAsync();
+    await host.WaitForShutdownAsync();
+    await host.TeardownAsync();
+}
+```
+
+### Migration from 2.x or earlier
+
+If you were already using this library prior to version 3.x, your code would typically look like this:
+
+```csharp
+await host.InitAsync();
+await host.RunAsync();
+```
+
+This will still work without changes. Just keep in mind that, as explained in the previous section, adding a call to `host.TeardownAsync()` after `host.RunAsync()` will not work. If you need teardown, the simplest way is to remove the explicit call to `InitAsync`, and call `InitAndRunAsync` instead of `RunAsync`.


### PR DESCRIPTION
Documents the changes introduced for #8
Add optional parameter to `AddAsyncInitializer` to specify the initializer's lifetime.