### PR TITLE
Timeout handling in initandrunasync

### DIFF
--- a/src/Extensions.Hosting.AsyncInitialization/Hosting/AsyncInitializationHostExtensions.cs
+++ b/src/Extensions.Hosting.AsyncInitialization/Hosting/AsyncInitializationHostExtensions.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="cancellationToken">Optionally propagates notifications that the operation should be cancelled</param>
         /// <remarks>
         /// Cancelling the <paramref name="cancellationToken"/> will not affect the teardown process. 
-        /// Teardown, when configured, is always performed, regardless if the process is cancelled or if an exception is thrown.
+        /// Teardown, when configured, is always performed, even if the process is cancelled or an exception is thrown.
         /// To prevent teardown from blocking forever, a <see cref="CancellationToken"/> with a <see cref="DefaultTeardownTimeout"/> value is passed to any registered initializers that implement <see cref="IAsyncTeardown"/>. 
         /// The entire teardown process will be cancelled if the timeout expires before all initializers have completed teardown.
         /// </remarks>

--- a/src/Extensions.Hosting.AsyncInitialization/Hosting/AsyncInitializationHostExtensions.cs
+++ b/src/Extensions.Hosting.AsyncInitialization/Hosting/AsyncInitializationHostExtensions.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Extensions.Hosting
                     var timeoutException = new TimeoutException("Teardown cancelled due to timeout.");
                     if (innerException != null)
                     {
-                        throw new AggregateException(timeoutException, innerException);
+                        throw new AggregateException(innerException, timeoutException);
                     }
                     throw timeoutException;
                 }

--- a/src/Extensions.Hosting.AsyncInitialization/Hosting/AsyncInitializationHostExtensions.cs
+++ b/src/Extensions.Hosting.AsyncInitialization/Hosting/AsyncInitializationHostExtensions.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Extensions.Hosting
         /// <param name="teardownTimeout">The <see cref="TimeSpan"/> timeout value to use for teardown. Setting this value to <see cref="Timeout.InfiniteTimeSpan"/> will disable timeout handling.</param>
         /// <remarks>
         /// Cancelling the <paramref name="cancellationToken"/> will not affect the teardown process. 
-        /// Teardown, when configured, is always performed, regardless if the process is cancelled or if an exception is thrown, using a timeout as specified by the <paramref name="teardownTimeout"/> parameter.
+        /// Teardown, when configured, is always performed, even if the process is cancelled or an exception is thrown, using a timeout as specified by the <paramref name="teardownTimeout"/> parameter.
         /// The entire teardown process will be cancelled if the timeout expires before all initializers have completed teardown.
         /// </remarks>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when an invalid <paramref name="teardownTimeout"/> value is passed.</exception>

--- a/src/Extensions.Hosting.AsyncInitialization/Hosting/AsyncInitializationHostExtensions.cs
+++ b/src/Extensions.Hosting.AsyncInitialization/Hosting/AsyncInitializationHostExtensions.cs
@@ -84,15 +84,14 @@ namespace Microsoft.Extensions.Hosting
             => await host.InitAndRunAsync(DefaultTeardownTimeout, cancellationToken).ConfigureAwait(false);
 
 
-        /// <param name="host">The <see cref="IHost"/> to initialize and run.</param>
+#pragma warning disable 1573
+        /// <inheritdoc  cref="InitAndRunAsync(IHost, CancellationToken)" path="/*[not(self::remarks)]"/>
         /// <param name="teardownTimeout">The <see cref="TimeSpan"/> timeout value to use for teardown. Setting this value to <see cref="Timeout.InfiniteTimeSpan"/> will disable timeout handling.</param>
-        /// <param name="cancellationToken">Optionally propagates notifications that the operation should be cancelled</param>
         /// <remarks>
         /// Cancelling the <paramref name="cancellationToken"/> will not affect the teardown process. 
         /// Teardown, when configured, is always performed, regardless if the process is cancelled or if an exception is thrown, using a timeout as specified by the <paramref name="teardownTimeout"/> parameter.
         /// The entire teardown process will be cancelled if the timeout expires before all initializers have completed teardown.
         /// </remarks>
-        /// <inheritdoc  cref="InitAndRunAsync(IHost, CancellationToken)"/>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when an invalid <paramref name="teardownTimeout"/> value is passed.</exception>
         public static async Task InitAndRunAsync(this IHost host, TimeSpan teardownTimeout, CancellationToken cancellationToken = default)
         {
@@ -121,6 +120,7 @@ namespace Microsoft.Extensions.Hosting
                 }
             }
         }
+#pragma warning restore 1573
 
         // wraps an IHost instance in an IAsyncDisposable 
         private static IAsyncDisposable AsAsyncDisposable(this IHost host)

--- a/src/Extensions.Hosting.AsyncInitialization/Hosting/AsyncInitializationHostExtensions.cs
+++ b/src/Extensions.Hosting.AsyncInitialization/Hosting/AsyncInitializationHostExtensions.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Extensions.Hosting
         /// <remarks>
         /// Cancelling the <paramref name="cancellationToken"/> will not affect the teardown process. 
         /// Teardown, when configured, is always performed, regardless if the process is cancelled or if an exception is thrown.
-        /// To prevent deadlocks during teardown, a <see cref="CancellationToken"/> with a <see cref="DefaultTeardownTimeout"/> value is passed to any registered initializers that implement <see cref="IAsyncTeardown"/>. 
+        /// To prevent teardown from blocking forever, a <see cref="CancellationToken"/> with a <see cref="DefaultTeardownTimeout"/> value is passed to any registered initializers that implement <see cref="IAsyncTeardown"/>. 
         /// The entire teardown process will be cancelled if the timeout expires before all initializers have completed teardown.
         /// </remarks>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation.</returns>

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationAndRunTests.cs
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationAndRunTests.cs
@@ -2,7 +2,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -162,7 +161,6 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
             {
                 services.AddAsyncInitializer(sp => new EndlessTeardownInitializer(supportsCancellation));
                 services.AddHostedService<StoppingService>();
-                //services.AddLogging(builder => builder.AddXUnit(OutputHelper).SetMinimumLevel(LogLevel.Debug));
             }, forceIDisposableHost: forceIDisposableHost);
 
             OutputHelper.WriteLine(host is IAsyncDisposable ? "Using IAsyncDisposable Host" : "Using IDisposable Host");
@@ -183,7 +181,6 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
             {
                 services.AddAsyncInitializer(sp => new EndlessTeardownInitializer(supportsCancellation));
                 services.AddHostedService<StoppingService>();
-                //services.AddLogging(builder => builder.AddXUnit(OutputHelper).SetMinimumLevel(LogLevel.Debug));
             });
 
             await Assert.ThrowsAsync<TimeoutException>(() => host.InitAndRunAsync(timeout));
@@ -200,15 +197,14 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
             {
                 services.AddAsyncInitializer(sp => new EndlessTeardownInitializer(supportsCancellation));
                 services.AddHostedService<FaultingService>();
-                //services.AddLogging(builder => builder.AddXUnit(OutputHelper).SetMinimumLevel(LogLevel.Debug));
             });
 
             var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync(timeout));
             Assert.IsType<AggregateException>(exception);
             var innerExceptions = ((AggregateException)exception).InnerExceptions;
             Assert.Collection(innerExceptions, 
-                item => Assert.IsType<TimeoutException>(item),
-                item => Assert.IsType<ApplicationException>(item));
+                item => Assert.IsType<ApplicationException>(item),
+                item => Assert.IsType<TimeoutException>(item));
         }
 
         [Theory]
@@ -223,7 +219,6 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
             {
                 services.AddAsyncInitializer(sp => A.Fake<IAsyncTeardown>());
                 services.AddHostedService<StoppingService>();
-                //services.AddLogging(builder => builder.AddXUnit(OutputHelper).SetMinimumLevel(LogLevel.Debug));
             }, forceIDisposableHost: forceIDisposableHost);
 
             OutputHelper.WriteLine(host is IAsyncDisposable ? "Using IAsyncDisposable Host" : "Using IDisposable Host");

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationAndRunTests.cs
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationAndRunTests.cs
@@ -361,53 +361,5 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
 
             await host.InitAndRunAsync();
         }
-
-        [Obsolete("DI Test. Not relevant in the context of Extensions.Hosting.AsyncInitialization")]
-        private async Task Scoped_disposable_dependency_is_disposed_twice_before_service()
-        {
-            var dependency = A.Fake<IDisposableDependency>();
-            var service = A.Fake<TestService>();
-
-            var host = CreateHost(
-                services =>
-                {
-                    services.AddScoped<IDependency>(sp => dependency);
-                    services.AddAsyncInitializer<InitializerWithTearDown>();
-                    services.AddHostedService(sp => service);
-                },
-                true);
-
-            var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
-            using var ctr = lifetime.ApplicationStarted.Register(lifetime.StopApplication);
-
-            await host.InitAndRunAsync();
-
-            A.CallTo(() => dependency.Dispose()).MustHaveHappenedTwiceExactly()
-               .Then(A.CallTo(() => service.Dispose()).MustHaveHappenedOnceExactly());
-        }
-
-        [Obsolete("DI Test. Not relevant in the context of Extensions.Hosting.AsyncInitialization")]
-        private async Task Singleton_disposable_dependency_is_disposed_once_after_service()
-        {
-            var dependency = A.Fake<IDisposableDependency>();
-            var service = A.Fake<TestService>();
-
-            var host = CreateHost(
-                services =>
-                {
-                    services.AddSingleton<IDependency>(sp => dependency);
-                    services.AddAsyncInitializer<InitializerWithTearDown>();
-                    services.AddHostedService(sp => service);
-                },
-                true);
-
-            var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
-            using var ctr = lifetime.ApplicationStarted.Register(lifetime.StopApplication);
-
-            await host.InitAndRunAsync();
-            A.CallTo(() => service.Dispose()).MustHaveHappenedOnceExactly()
-                .Then(A.CallTo(() => dependency.Dispose()).MustHaveHappenedOnceExactly());
-        }
-
     }
 }

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationAndRunTests.cs
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncInitializationAndRunTests.cs
@@ -42,17 +42,17 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
                 services.AddAsyncInitializer(initializer1);
                 services.AddAsyncInitializer(initializer2);
                 services.AddAsyncInitializer(initializer3);
-                services.AddHostedService<TestService>();
+                services.AddHostedService<StoppingService>();
             });
 
             await host.InitAndRunAsync();
             
-            A.CallTo(() => initializer1.InitializeAsync(default)).MustHaveHappenedOnceExactly()
-                .Then(A.CallTo(() => initializer2.InitializeAsync(default)).MustHaveHappenedOnceExactly())
-                .Then(A.CallTo(() => initializer3.InitializeAsync(default)).MustHaveHappenedOnceExactly())
-                .Then(A.CallTo(() => initializer3.TeardownAsync(default)).MustHaveHappenedOnceExactly())
-                .Then(A.CallTo(() => initializer2.TeardownAsync(default)).MustHaveHappenedOnceExactly())
-                .Then(A.CallTo(() => initializer1.TeardownAsync(default)).MustHaveHappenedOnceExactly());
+            A.CallTo(() => initializer1.InitializeAsync(A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly()
+                .Then(A.CallTo(() => initializer2.InitializeAsync(A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly())
+                .Then(A.CallTo(() => initializer3.InitializeAsync(A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly())
+                .Then(A.CallTo(() => initializer3.TeardownAsync(A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly())
+                .Then(A.CallTo(() => initializer2.TeardownAsync(A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly())
+                .Then(A.CallTo(() => initializer1.TeardownAsync(A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly());
         }
 
         [Fact]
@@ -62,7 +62,7 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
             var initializer1 = A.Fake<IAsyncTeardown>();
             var initializer2 = A.Fake<IAsyncTeardown>();
             var initializer3 = A.Fake<IAsyncTeardown>();
-            var service = A.Fake<BackgroundService>();
+            var service = A.Fake<TestService>();
 
             A.CallTo(() => initializer1.InitializeAsync(A<CancellationToken>._)).Invokes(_ => cancellationTokenSource.Cancel());
 
@@ -74,24 +74,23 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
                 services.AddHostedService(factory => service);
             });
 
-            var exception = await Record.ExceptionAsync(() => host.InitAndRunAsync(cancellationTokenSource.Token));
-            Assert.IsType<OperationCanceledException>(exception);
+            await Assert.ThrowsAsync<OperationCanceledException>(() => host.InitAndRunAsync(cancellationTokenSource.Token));
 
             A.CallTo(() => initializer1.InitializeAsync(A<CancellationToken>._)).MustHaveHappenedOnceExactly();
             A.CallTo(() => initializer2.InitializeAsync(A<CancellationToken>._)).MustNotHaveHappened();
             A.CallTo(() => initializer3.InitializeAsync(A<CancellationToken>._)).MustNotHaveHappened();
-            A.CallTo(() => initializer1.TeardownAsync(CancellationToken.None)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => initializer2.TeardownAsync(CancellationToken.None)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => initializer3.TeardownAsync(CancellationToken.None)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => service.StartAsync(CancellationToken.None)).MustNotHaveHappened();
+            A.CallTo(() => initializer1.TeardownAsync(A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => initializer2.TeardownAsync(A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => initializer3.TeardownAsync(A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => service.StartAsync(A<CancellationToken>._)).MustNotHaveHappened();
         }
 
         [Fact]
         public async Task Failing_initializer_skips_host_run_and_calls_teardown()
         {
-            var service = A.Fake<BackgroundService>();
+            var service = A.Fake<TestService>();
             var initializer = A.Fake<IAsyncTeardown>();
-            A.CallTo(() => initializer.InitializeAsync(default)).ThrowsAsync(() => new Exception("oops"));
+            A.CallTo(() => initializer.InitializeAsync(A<CancellationToken>.Ignored)).ThrowsAsync(() => new Exception("oops"));
 
             var host = CreateHost(services =>
             {
@@ -103,9 +102,9 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
             Assert.IsType<Exception>(exception);
             Assert.Equal("oops", exception.Message);
 
-            A.CallTo(() => initializer.InitializeAsync(CancellationToken.None)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => service.StartAsync(CancellationToken.None)).MustNotHaveHappened();
-            A.CallTo(() => initializer.TeardownAsync(CancellationToken.None)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => initializer.InitializeAsync(A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => service.StartAsync(A<CancellationToken>.Ignored)).MustNotHaveHappened();
+            A.CallTo(() => initializer.TeardownAsync(A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly();
         }
 
         [Theory]
@@ -115,21 +114,15 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
         {
             var host = CreateHost(services =>
             {
-                services.AddScoped<IDependency, DisposableDependency>();
-                services.AddTransient(factory => OutputHelper);
-                services.AddAsyncInitializer<InitializerWithTearDown>();
-                services.AddHostedService<TestService>();
-            }, true);
-
-            if (forceIDisposableHost) 
-                host = new SyncDisposableHostWrapper(host);
+                services.AddAsyncInitializer(sp => A.Fake<IAsyncTeardown>());
+                services.AddHostedService<StoppingService>();
+            }, forceIDisposableHost: forceIDisposableHost);
 
             OutputHelper.WriteLine(host is IAsyncDisposable ? "Using IAsyncDisposable Host" : "Using IDisposable Host");
 
             await host.InitAndRunAsync();
-            
-            var exception = Record.Exception(() => host.Services.CreateScope());
-            Assert.IsType<ObjectDisposedException>(exception);
+            Assert.Throws<ObjectDisposedException>(host.Services.CreateScope);
+
         }
 
         [Theory]
@@ -138,12 +131,12 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
         public async Task Host_is_disposed_after_failing_teardown(bool forceIDisposableHost)
         {
             var initializer = A.Fake<IAsyncTeardown>();
-            A.CallTo(() => initializer.TeardownAsync(default)).ThrowsAsync(() => new Exception("oops"));
+            A.CallTo(() => initializer.TeardownAsync(A<CancellationToken>.Ignored)).ThrowsAsync(() => new Exception("oops"));
 
             var host = CreateHost(services =>
             {
                 services.AddAsyncInitializer(initializer);
-                services.AddHostedService<TestService>();
+                services.AddHostedService<StoppingService>();
             }, forceIDisposableHost: forceIDisposableHost);
 
             OutputHelper.WriteLine(host is IAsyncDisposable ? "Using IAsyncDisposable Host" : "Using IDisposable Host");
@@ -152,9 +145,71 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
             Assert.IsType<Exception>(exception);
             Assert.Equal("oops", exception.Message);
 
-            exception = Record.Exception(() => host.Services.CreateScope());
-            Assert.IsType<ObjectDisposedException>(exception);
+            Assert.Throws<ObjectDisposedException>(host.Services.CreateScope);
         }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(true, true)]
+        public async Task Host_is_disposed_after_teardown_timeout(bool forceIDisposableHost, bool supportsCancellation)
+        {
+            var timeout = TimeSpan.FromMilliseconds(100);  
+
+            var host = CreateHost(services =>
+            {
+                services.AddAsyncInitializer(sp => new EndlessTeardownInitializer(supportsCancellation));
+                services.AddHostedService<StoppingService>();
+                //services.AddLogging(builder => builder.AddXUnit(OutputHelper).SetMinimumLevel(LogLevel.Debug));
+            }, forceIDisposableHost: forceIDisposableHost);
+
+            OutputHelper.WriteLine(host is IAsyncDisposable ? "Using IAsyncDisposable Host" : "Using IDisposable Host");
+
+            await Assert.ThrowsAnyAsync<TimeoutException>(() => host.InitAndRunAsync(timeout));
+
+            Assert.Throws<ObjectDisposedException>(host.Services.CreateScope);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task InitAndRunAsync_throws_TimeoutException_when_teardown_exceeds_timeout(bool supportsCancellation)
+        {
+            var timeout = TimeSpan.FromMilliseconds(100);
+
+            var host = CreateHost(services =>
+            {
+                services.AddAsyncInitializer(sp => new EndlessTeardownInitializer(supportsCancellation));
+                services.AddHostedService<StoppingService>();
+                //services.AddLogging(builder => builder.AddXUnit(OutputHelper).SetMinimumLevel(LogLevel.Debug));
+            });
+
+            await Assert.ThrowsAsync<TimeoutException>(() => host.InitAndRunAsync(timeout));
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        
+        public async Task Host_is_disposed_with_infinite_teardown_timeout(bool forceIDisposableHost)
+        {
+            var timeout = Timeout.InfiniteTimeSpan;
+
+            var host = CreateHost(services =>
+            {
+                services.AddAsyncInitializer(sp => A.Fake<IAsyncTeardown>());
+                services.AddHostedService<StoppingService>();
+                //services.AddLogging(builder => builder.AddXUnit(OutputHelper).SetMinimumLevel(LogLevel.Debug));
+            }, forceIDisposableHost: forceIDisposableHost);
+
+            OutputHelper.WriteLine(host is IAsyncDisposable ? "Using IAsyncDisposable Host" : "Using IDisposable Host");
+
+            await host.InitAndRunAsync(timeout);
+
+            Assert.Throws<ObjectDisposedException>(host.Services.CreateScope);
+        }
+
 
         [Theory]
         [InlineData(false)]
@@ -176,8 +231,7 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
             Assert.IsType<Exception>(exception);
             Assert.Equal("oops", exception.Message);
 
-            exception = Record.Exception(() => host.Services.CreateScope());
-            Assert.IsType<ObjectDisposedException>(exception);
+            Assert.Throws<ObjectDisposedException>(host.Services.CreateScope);
         }
 
         [Theory]
@@ -185,40 +239,104 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
         [InlineData(true)]
         public async Task Host_is_disposed_after_cancellation(bool forceIDisposableHost)
         {
-
-            using var cancellationTokenSource = new CancellationTokenSource();
-            var service = A.Fake<TestService>();
-            A.CallTo(() => service.StartAsync(A<CancellationToken>._)).Invokes(_ => cancellationTokenSource.Cancel()).CallsBaseMethod();
-
             var host = CreateHost(services =>
             {
                 services.AddAsyncInitializer(sp => A.Fake<IAsyncTeardown>());
-                services.AddHostedService(factory => service);
+                services.AddHostedService<TestService>();
             }, forceIDisposableHost: forceIDisposableHost);
 
             OutputHelper.WriteLine(host is IAsyncDisposable ? "Using IAsyncDisposable Host" : "Using IDisposable Host");
 
-            await Assert.ThrowsAsync<TaskCanceledException>(() => host.InitAndRunAsync(cancellationTokenSource.Token));
+            var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+            using var cancellationTokenSource = new CancellationTokenSource();
+            using var ctr = lifetime.ApplicationStarted.Register(cancellationTokenSource.Cancel);
 
-            var exception = Record.Exception(() => host.Services.CreateScope());
-            Assert.IsType<ObjectDisposedException>(exception);
+            await host.InitAndRunAsync(cancellationTokenSource.Token);
+
+            Assert.Throws<ObjectDisposedException>(host.Services.CreateScope);
         }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task Host_is_disposed_after_service_fails(bool forceIDisposableHost)
+        {
+            var host = CreateHost(services =>
+            {
+                services.AddAsyncInitializer(sp => A.Fake<IAsyncTeardown>());
+                services.AddHostedService<FaultingService>();   
+            }, forceIDisposableHost: forceIDisposableHost);
+
+            OutputHelper.WriteLine(host is IAsyncDisposable ? "Using IAsyncDisposable Host" : "Using IDisposable Host");
+
+            await Assert.ThrowsAsync<ApplicationException>(() => host.InitAndRunAsync()); 
+            Assert.Throws<ObjectDisposedException>(host.Services.CreateScope);  
+        }
+
 
         [Fact]
         public async Task Initializer_with_teardown_and_scoped_dependency_is_resolved()
         {
+
             var host = CreateHost(
                 services =>
                 {
-                    services.AddScoped<IDependency, DisposableDependency>();
+                    services.AddScoped(sp => A.Fake<IDependency>());
                     services.AddAsyncInitializer<InitializerWithTearDown>();
-                    services.AddTransient(factory => OutputHelper);
-                    services.AddHostedService<TestService>();
+                    services.AddHostedService<StoppingService>();
                 },
                 true);
 
             await host.InitAndRunAsync();    
         }
+
+        [Fact]
+        public async Task Scoped_disposable_dependency_is_disposed_twice_before_service()
+        {
+            var dependency = A.Fake<IDisposableDependency>();
+            var service = A.Fake<TestService>();
+
+            var host = CreateHost(
+                services =>
+                {
+                    services.AddScoped<IDependency>(sp => dependency);
+                    services.AddAsyncInitializer<InitializerWithTearDown>();
+                    services.AddHostedService(sp => service);
+                },
+                true);
+
+            var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+            using var ctr = lifetime.ApplicationStarted.Register(lifetime.StopApplication);
+
+            await host.InitAndRunAsync();
+
+            A.CallTo(() => dependency.Dispose()).MustHaveHappenedTwiceExactly()
+               .Then(A.CallTo(() => service.Dispose()).MustHaveHappenedOnceExactly());
+        }
+
+        [Fact]
+        public async Task Singleton_disposable_dependency_is_disposed_once_after_service()
+        {
+            var dependency = A.Fake<IDisposableDependency>();
+            var service = A.Fake<TestService>();
+
+            var host = CreateHost(
+                services =>
+                {
+                    services.AddSingleton<IDependency>(sp => dependency);
+                    services.AddAsyncInitializer<InitializerWithTearDown>();
+                    services.AddHostedService(sp => service);
+                },
+                true);
+
+            var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+            using var ctr = lifetime.ApplicationStarted.Register(lifetime.StopApplication);
+
+            await host.InitAndRunAsync();
+            A.CallTo(() => service.Dispose()).MustHaveHappenedOnceExactly()
+                .Then(A.CallTo(() => dependency.Dispose()).MustHaveHappenedOnceExactly());
+        }
+
 
         [Fact]
         public async Task Single_initializer_with_teardown_is_called()
@@ -228,20 +346,20 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
             var host = CreateHost(services =>
             {
                 services.AddAsyncInitializer(initializer);
-                services.AddHostedService<TestService>();
+                services.AddHostedService<StoppingService>();
             });
 
             await host.InitAndRunAsync();
             
-            A.CallTo(() => initializer.InitializeAsync(CancellationToken.None)).MustHaveHappenedOnceExactly();
-            A.CallTo(() => initializer.TeardownAsync(CancellationToken.None)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => initializer.InitializeAsync(A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => initializer.TeardownAsync(A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly();
         }
 
         [Fact]
-        public async Task Cancelled_call_does_nothing()
+        public async Task InitAndRunAsync_throws_OperationCancelledException_when_called_with_cancelled_token()
         {
             var initializer = A.Fake<IAsyncTeardown>();
-            var service = A.Fake<BackgroundService>();
+            var service = A.Fake<TestService>();
 
             var host = CreateHost(services =>
             {
@@ -251,12 +369,21 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
 
             await Assert.ThrowsAsync<OperationCanceledException>(() => host.InitAndRunAsync(new CancellationToken(true)));
             
-            A.CallTo(() => initializer.InitializeAsync(CancellationToken.None)).MustNotHaveHappened();
-            A.CallTo(() => initializer.TeardownAsync(CancellationToken.None)).MustNotHaveHappened();
-            A.CallTo(() => service.StartAsync(default)).MustNotHaveHappened();
+            A.CallTo(() => initializer.InitializeAsync(A<CancellationToken>.Ignored)).MustNotHaveHappened();
+            A.CallTo(() => initializer.TeardownAsync(A<CancellationToken>.Ignored)).MustNotHaveHappened();
+            A.CallTo(() => service.StartAsync(A<CancellationToken>.Ignored)).MustNotHaveHappened();
         }
 
+        [Fact]
+        public async Task InitAndRunAsync_without_initializer_does_not_fail()
+        {
+            var host = CreateHost(services =>
+            {
+                services.AddAsyncInitialization();
+                services.AddHostedService<StoppingService>();
+            });
 
-        
+            await host.InitAndRunAsync();
+        }
     }
 }

--- a/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncTeardownTests.cs
+++ b/tests/Extensions.Hosting.AsyncInitialization.Tests/AsyncTeardownTests.cs
@@ -5,20 +5,12 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using Xunit.Abstractions;
 using static Extensions.Hosting.AsyncInitialization.Tests.CommonTestTypes;
 
 namespace Extensions.Hosting.AsyncInitialization.Tests
 {
     public class AsyncTeardownTests
     {
-        public AsyncTeardownTests(ITestOutputHelper testOutput)
-        {
-            OutputHelper = testOutput;
-        }
-        private ITestOutputHelper OutputHelper { get; }
-
-
         [Fact]
         public async Task Single_teardown_is_called()
         {
@@ -115,14 +107,13 @@ namespace Extensions.Hosting.AsyncInitialization.Tests
         }
 
         [Fact]
-        public async Task teardown_with_scoped_dependency_is_resolved()
+        public async Task Teardown_with_scoped_dependency_is_resolved()
         {
             var host = CreateHost(
                 services =>
                 {
                     services.AddScoped(sp => A.Fake<IDependency>());
                     services.AddAsyncInitializer<InitializerWithTearDown>();
-                    services.AddTransient<ITestOutputHelper>(factory => OutputHelper);
                 },
                 true);
 


### PR DESCRIPTION
Adding support for timeout-cancellation when calling host.TeardownAsync() in InitAndRunAsync().


```
try
{...}
finally
{
   using var cts = new CancellationTokenSource(teardownTimeout);
   try
   {
      await host.TeardownAsync(cts.Token).WaitAsync(cts.Token).ConfigureAwait(false);
   }
   catch (OperationCanceledException) when (cts.IsCancellationRequested)
   {
      throw new TimeoutException("Teardown cancelled due to timeout.");
   }
}
```

You will notice that I'm passing the timeout token to both the `RootInitializer` (and thus all initializers) as well as awaiting the entire call with the timeout token. This is to ensure that teardown is cancelled even in the presence of initializers that do provide proper support for CancellationToken in their `TeardownAsync()` method. Maybe a bit brutal, but ensures the method does not deadlock. 
-> Up for discussion

Timeout-handling can be disabled by passing a Timeout.InfiniteTimeSpan value.
The code then behaves as if a CancellationToken.None were passed.

I'm also explicitly throwing a TimeoutException() so the user knows what happend. 
Code analysis though suggests not to throw exceptions in a finally-block.
-> Up for discussion

I have a strong preference for method overloads vs. optional parameters, so you will find an additional method signature for `InitAndRunAsync()`.

Also, testcases and CommonTypes have been ammended and refactored because they were a bit messy and heavy.

Cheers
Alexander